### PR TITLE
Updates to https://github.com/elastic/apm-agent-python/pull/1549

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,10 +39,12 @@ endif::[]
 [float]
 ===== Bug fixes
 
-* Differentiate Lambda URLs from API Gateway in AWS Lambda integration {pull}#1609[#1609]
-* Restrict the size of Django request bodies to prevent APM Server rejection {pull}#1610[#1610]
-* Restrict length of `exception.message` for exceptions captured by the agent {pull}#1619[#1619]
-* Fix error when using elasticsearch(sniff_on_start=True) {pull}#1618[#1618]
+* Differentiate Lambda URLs from API Gateway in AWS Lambda integration {pull}1609[#1609]
+* Restrict the size of Django request bodies to prevent APM Server rejection {pull}1610[#1610]
+* Restrict length of `exception.message` for exceptions captured by the agent {pull}1619[#1619]
+* Restrict length of Starlette request bodies {pull}1549[#1549]
+* Fix error when using elasticsearch(sniff_on_start=True) {pull}1618[#1618]
+* Improve handling of ignored URLs and capture_body=off for Starlette {pull}1549[#1549]
 
 
 
@@ -55,7 +57,7 @@ endif::[]
 [float]
 ===== Features
 
-* Added lambda support for ELB triggers {pull}#1605[#1605]
+* Added lambda support for ELB triggers {pull}1605[#1605]
 
 [[release-notes-6.10.2]]
 ==== 6.10.2 - 2022-08-04

--- a/elasticapm/contrib/starlette/__init__.py
+++ b/elasticapm/contrib/starlette/__init__.py
@@ -47,6 +47,7 @@ from elasticapm.conf import constants
 from elasticapm.contrib.asyncio.traces import set_context
 from elasticapm.contrib.starlette.utils import get_body, get_data_from_request, get_data_from_response
 from elasticapm.utils.disttracing import TraceParent
+from elasticapm.utils.encoding import long_field
 from elasticapm.utils.logging import get_logger
 
 logger = get_logger("elasticapm.errors.client")
@@ -166,7 +167,7 @@ class ElasticAPM:
 
             async def mocked_receive() -> Message:
                 await asyncio.sleep(0)
-                return {"type": "http.request", "body": b"".join(body)}
+                return {"type": "http.request", "body": long_field(b"".join(body))}
 
             receive = mocked_receive
 

--- a/elasticapm/utils/encoding.py
+++ b/elasticapm/utils/encoding.py
@@ -229,6 +229,9 @@ def long_field(data):
     If the given data, converted to string, is longer than LONG_FIELD_MAX_LENGTH,
     truncate it to LONG_FIELD_MAX_LENGTH-1, adding the "…" character at the end.
 
+    If data is bytes, truncate it to LONG_FIELD_MAX_LENGTH-3, adding b"..." to
+    the end.
+
     Returns the original data if truncation is not required.
 
     Per https://github.com/elastic/apm/blob/main/specs/agents/field-limits.md#long_field_max_length-configuration,
@@ -242,9 +245,12 @@ def long_field(data):
 
     Other fields should be truncated via `elasticapm.utils.encoding.keyword_field()`
     """
-    string = str(data) if not isinstance(data, str) else data
-    if len(string) > LONG_FIELD_MAX_LENGTH:
-        return string[: LONG_FIELD_MAX_LENGTH - 1] + "…"
+    str_or_bytes = str(data) if not isinstance(data, (str, bytes)) else data
+    if len(str_or_bytes) > LONG_FIELD_MAX_LENGTH:
+        if isinstance(str_or_bytes, bytes):
+            return str_or_bytes[: LONG_FIELD_MAX_LENGTH - 3] + b"..."
+        else:
+            return str_or_bytes[: LONG_FIELD_MAX_LENGTH - 1] + "…"
     else:
         return data
 


### PR DESCRIPTION
Adds support for limiting the body length in starlette, plus CHANGELOG for https://github.com/elastic/apm-agent-python/pull/1549
